### PR TITLE
Allow support for other content types middleware will parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/*/browser
 package-lock.json
 .project
 .settings/
+
+.vscode/

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,8 +2,8 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expressAppConfig = void 0;
 const express_app_config_1 = require("./middleware/express.app.config");
-function expressAppConfig(definitionPath, appOptions, customMiddlewares) {
-    return new express_app_config_1.ExpressAppConfig(definitionPath, appOptions, customMiddlewares);
+function expressAppConfig(definitionPath, appOptions, customMiddlewares, jsonExpressType) {
+    return new express_app_config_1.ExpressAppConfig(definitionPath, appOptions, customMiddlewares, jsonExpressType);
 }
 exports.expressAppConfig = expressAppConfig;
 //# sourceMappingURL=index.js.map

--- a/dist/middleware/express.app.config.js
+++ b/dist/middleware/express.app.config.js
@@ -13,7 +13,7 @@ const fs = require("fs");
 const jsyaml = require("js-yaml");
 const OpenApiValidator = require("express-openapi-validator");
 class ExpressAppConfig {
-    constructor(definitionPath, appOptions, customMiddlewares) {
+    constructor(definitionPath, appOptions, customMiddlewares, jsonExpressType = 'application/json') {
         this.definitionPath = definitionPath;
         this.routingOptions = appOptions.routing;
         this.parserLimit = appOptions.parserLimit || '100kb';
@@ -28,7 +28,7 @@ class ExpressAppConfig {
         this.app.use(bodyParser.json({ limit: this.parserLimit }));
         this.app.use(bodyParser.raw({ type: 'application/pdf', limit: this.parserLimit }));
         this.app.use(this.configureLogger(appOptions.logging));
-        this.app.use(express.json());
+        this.app.use(express.json({type:jsonExpressType}));
         this.app.use(express.urlencoded({ extended: false }));
         this.app.use(cookieParser());
         const swaggerUi = new swagger_ui_1.SwaggerUI(swaggerDoc, appOptions.swaggerUI);

--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -21,7 +21,14 @@ export class ExpressAppConfig {
     private definitionPath;
     private openApiValidatorOptions;
 
-    constructor(definitionPath: string, appOptions: Oas3AppOptions, customMiddlewares?: OpenApiRequestHandler[]) {
+    /**
+     * 
+     * @param definitionPath full path to the Open Api Swagger file
+     * @param appOptions 
+     * @param customMiddlewares 
+     * @param jsonExpressType Allowed media type that the middleware will parse, defaults to 'application/json'
+     */
+    constructor(definitionPath: string, appOptions: Oas3AppOptions, customMiddlewares?: OpenApiRequestHandler[], jsonExpressType = 'application/json') {
         this.definitionPath = definitionPath;
         this.routingOptions = appOptions.routing;
         this.parserLimit = appOptions.parserLimit || '100kb';
@@ -41,7 +48,7 @@ export class ExpressAppConfig {
         this.app.use(bodyParser.raw({ type: 'application/pdf', limit: this.parserLimit }));
 
         this.app.use(this.configureLogger(appOptions.logging));
-        this.app.use(express.json());
+        this.app.use(express.json({type:jsonExpressType}));
         this.app.use(express.urlencoded({ extended: false }));
         this.app.use(cookieParser());
 


### PR DESCRIPTION
As per https://expressjs.com/en/api.html the express middleware will by default only parse application/json content types. With this PR you can choose which content-types can be processed.

In my case, I wanted my api to support both application/json as application/json-patch+json